### PR TITLE
 Fix minimum publishing interval calculation

### DIFF
--- a/src/plugins/opcua/open62541/qopen62541backend.cpp
+++ b/src/plugins/opcua/open62541/qopen62541backend.cpp
@@ -289,7 +289,7 @@ QOpen62541Subscription *Open62541AsyncBackend::getSubscription(const QOpcUaMonit
         return nullptr;
     }
     m_subscriptions[id] = sub;
-    if (sub->interval() > settings.samplingInterval()) // The publishing interval has been revised by the server.
+    if (sub->interval() > settings.publishingInterval()) // The publishing interval has been revised by the server.
         m_minPublishingInterval = sub->interval();
     // This must be a queued connection to prevent the slot from being called while the client is inside UA_Client_runAsync().
     QObject::connect(sub, &QOpen62541Subscription::timeout, this, &Open62541AsyncBackend::handleSubscriptionTimeout, Qt::QueuedConnection);

--- a/src/plugins/opcua/uacpp/quacppbackend.cpp
+++ b/src/plugins/opcua/uacpp/quacppbackend.cpp
@@ -693,7 +693,7 @@ QUACppSubscription *UACppAsyncBackend::getSubscription(const QOpcUaMonitoringPar
         delete sub;
         return nullptr;
     }
-    if (sub->interval() > settings.samplingInterval()) // The publishing interval has been revised by the server.
+    if (sub->interval() > settings.publishingInterval()) // The publishing interval has been revised by the server.
         m_minPublishingInterval = sub->interval();
     m_subscriptions[id] = sub;
     return sub;


### PR DESCRIPTION
It seems that, without the fix, the following code will make the client use the 500 ms subscription for the second monitored item instead of creating a new 100 ms subscription.

This seems to happen only if enableMonitoring() is called for the first time with a sample time that is bigger than the one specified by the following calls.

```
QOpcUaNode* node1 = opcua_client->node(id1);
QOpcUaNode* node2 = opcua_client->node(id2);
// To replicate the bug the following line should be the first call to enableMonitoring()
node1->enableMonitoring(QOpcUa::NodeAttribute::Value, QOpcUaMonitoringParameters(500);
node2->enableMonitoring(QOpcUa::NodeAttribute::Value, QOpcUaMonitoringParameters(100);
```