### PR TITLE
Possible fix for X509 compilation errors for 5.15.x versions

### DIFF
--- a/dist/changes-5.15.2
+++ b/dist/changes-5.15.2
@@ -1,0 +1,38 @@
+Qt 5.15.2 is a bug-fix release. It maintains both forward and backward
+compatibility (source and binary) with Qt 5.15.1.
+
+For more details, refer to the online documentation included in this
+distribution. The documentation is also available online:
+
+  https://doc.qt.io/qt-5.15/index.html
+
+The Qt version 5.15 series is binary compatible with the 5.14.x series.
+Applications compiled for 5.14 will continue to run with 5.15.
+
+Some of the changes listed in this file include issue tracking numbers
+corresponding to tasks in the Qt Bug Tracker:
+
+  https://bugreports.qt.io/
+
+Each of these identifiers can be entered in the bug tracker to obtain more
+information about a particular change.
+
+****************************************************************************
+*                   Important Behavior Changes                             *
+****************************************************************************
+
+****************************************************************************
+*                          Library                                         *
+****************************************************************************
+
+Open62541 Plugin
+-------
+
+- Fix loading of PEM encoded certificates and private keys
+- Fix config test for system-open62541
+
+QML API
+-------
+
+ - Monitoring for value nodes is now reestablished on reconnect
+

--- a/src/opcua/x509/openssl_symbols.cpp
+++ b/src/opcua/x509/openssl_symbols.cpp
@@ -273,7 +273,7 @@ DEFINEFUNC3(int, BIO_read, BIO *a, a, void *b, b, int c, c, return -1, return)
 DEFINEFUNC3(int, BIO_write, BIO *a, a, const void *b, b, int c, c, return -1, return)
 DEFINEFUNC(int, BN_num_bits, const BIGNUM *a, a, return 0, return)
 DEFINEFUNC2(BN_ULONG, BN_mod_word, const BIGNUM *a, a, BN_ULONG w, w, return static_cast<BN_ULONG>(-1), return)
-DEFINEFUNC2(int, BN_set_word, const BIGNUM *a, a, BN_ULONG w, w, return 0, return)
+DEFINEFUNC2(int, BN_set_word, BIGNUM *a, a, BN_ULONG w, w, return 0, return)
 DEFINEFUNC(BIGNUM *, BN_new, void, DUMMYARG, return nullptr, return)
 DEFINEFUNC(void, BN_clear, BIGNUM *bignum, bignum, return, return)
 DEFINEFUNC(void, BN_free, BIGNUM *bignum, bignum, return, return)
@@ -339,7 +339,7 @@ DEFINEFUNC4(DH *, PEM_read_bio_DHparams, BIO *a, a, DH **b, b, pem_password_cb *
 DEFINEFUNC7(int, PEM_write_bio_DSAPrivateKey, BIO *a, a, DSA *b, b, const EVP_CIPHER *c, c, unsigned char *d, d, int e, e, pem_password_cb *f, f, void *g, g, return 0, return)
 DEFINEFUNC7(int, PEM_write_bio_RSAPrivateKey, BIO *a, a, RSA *b, b, const EVP_CIPHER *c, c, unsigned char *d, d, int e, e, pem_password_cb *f, f, void *g, g, return 0, return)
 DEFINEFUNC7(int, PEM_write_bio_PrivateKey, BIO *a, a, EVP_PKEY *b, b, const EVP_CIPHER *c, c, unsigned char *d, d, int e, e, pem_password_cb *f, f, void *g, g, return 0, return)
-DEFINEFUNC7(int, PEM_write_bio_PKCS8PrivateKey, BIO *a, a, EVP_PKEY *b, b, const EVP_CIPHER *c, c, unsigned char *d, d, int e, e, pem_password_cb *f, f, void *g, g, return 0, return)
+DEFINEFUNC7(int, PEM_write_bio_PKCS8PrivateKey, BIO *a, a, EVP_PKEY *b, b, const EVP_CIPHER *c, c, char *d, d, int e, e, pem_password_cb *f, f, void *g, g, return 0, return)
 #ifndef OPENSSL_NO_EC
 DEFINEFUNC7(int, PEM_write_bio_ECPrivateKey, BIO *a, a, EC_KEY *b, b, const EVP_CIPHER *c, c, unsigned char *d, d, int e, e, pem_password_cb *f, f, void *g, g, return 0, return)
 #endif

--- a/src/opcua/x509/openssl_symbols_p.h
+++ b/src/opcua/x509/openssl_symbols_p.h
@@ -279,7 +279,7 @@ int q_BN_is_word(BIGNUM *a, BN_ULONG w);
 #endif // !opensslv11
 
 BN_ULONG q_BN_mod_word(const BIGNUM *a, BN_ULONG w);
-int q_BN_set_word(const BIGNUM *a, BN_ULONG w);
+int q_BN_set_word(BIGNUM *a, BN_ULONG w);
 BIGNUM *q_BN_new();
 void q_BN_clear(BIGNUM *a);
 void q_BN_free(BIGNUM *a);
@@ -385,7 +385,7 @@ int q_PEM_write_bio_RSAPrivateKey(BIO *a, RSA *b, const EVP_CIPHER *c, unsigned 
                                   int e, pem_password_cb *f, void *g);
 int q_PEM_write_bio_PrivateKey(BIO *a, EVP_PKEY *b, const EVP_CIPHER *c, unsigned char *d,
                                int e, pem_password_cb *f, void *g);
-int q_PEM_write_bio_PKCS8PrivateKey(BIO *a, EVP_PKEY *b, const EVP_CIPHER *c, unsigned char *d,
+int q_PEM_write_bio_PKCS8PrivateKey(BIO *a, EVP_PKEY *b, const EVP_CIPHER *c, char *d,
                                int e, pem_password_cb *f, void *g);
 #ifndef OPENSSL_NO_EC
 int q_PEM_write_bio_ECPrivateKey(BIO *a, EC_KEY *b, const EVP_CIPHER *c, unsigned char *d,

--- a/src/opcua/x509/qopcuakeypair_openssl.cpp
+++ b/src/opcua/x509/qopcuakeypair_openssl.cpp
@@ -240,7 +240,7 @@ QByteArray QOpcUaKeyPairPrivate::privateKeyToByteArray(QOpcUaKeyPair::Cipher cip
     }
 
     if (0 == q_PEM_write_bio_PKCS8PrivateKey(bio, m_keyData, enc,
-                                         enc ? (unsigned char*)password.toUtf8().constData() : NULL,
+                                         enc ? (char*)password.toUtf8().constData() : NULL,
                                          enc ? password.length() : 0,
                                          NULL /* callback */, NULL /* userdata */)) {
         qCWarning(lcSsl) << "Failed to write private key:" << getOpenSslError();


### PR DESCRIPTION
Dear developers,

Linux distribution with: Qt-5.15.2, GCC-10.3, OpenSSL-1.1.1m

I usually use 5.12.2 version of OPC UA.  I have a compilation error in more recent versions (with openssl support ).

``` 
In file included from x509/openssl_symbols.cpp:57:
x509/openssl_symbols.cpp: In function 'int q_BN_set_word(const BIGNUM*, long unsigned int)':
x509/openssl_symbols.cpp:276:48: error: invalid conversion from 'const BIGNUM*' {aka 'const bignum_st*'} to 'BIGNUM*' {aka 'bignum_st*'} [-fpermissive]
  276 | DEFINEFUNC2(int, BN_set_word, const BIGNUM *a, a, BN_ULONG w, w, return 0, return)
      |                                                ^
      |                                                |
      |                                                const BIGNUM* {aka const bignum_st*}
x509/openssl_symbols_p.h:217:45: note: in definition of macro 'DEFINEFUNC2'
  217 |     ret q_##func(arg1, arg2) { funcret func(a, b); }
      |                                             ^
In file included from /usr/include/openssl/asn1.h:23,
                 from x509/openssl_symbols_p.h:59,
                 from x509/openssl_symbols.cpp:57:
/usr/include/openssl/bn.h:271:25: note:   initializing argument 1 of 'int BN_set_word(BIGNUM*, long unsigned int)'
  271 | int BN_set_word(BIGNUM *a, BN_ULONG w);
      |                 ~~~~~~~~^
In file included from x509/openssl_symbols.cpp:57:
x509/openssl_symbols.cpp: In function 'int q_PEM_write_bio_PKCS8PrivateKey(BIO*, EVP_PKEY*, const EVP_CIPHER*, unsigned char*, int, int (*)(char*, int, int, void*), void*)':
x509/openssl_symbols.cpp:342:118: error: invalid conversion from 'unsigned char*' to 'char*' [-fpermissive]
  342 | DEFINEFUNC7(int, PEM_write_bio_PKCS8PrivateKey, BIO *a, a, EVP_PKEY *b, b, const EVP_CIPHER *c, c, unsigned char *d, d, int e, e, pem_password_cb *f, f, void *g, g, return 0, return)
      |                                                                                                                      ^
      |                                                                                                                      |
      |                                                                                                                      unsigned char*
x509/openssl_symbols_p.h:237:84: note: in definition of macro 'DEFINEFUNC7'
  237 |     ret q_##func(arg1, arg2, arg3, arg4, arg5, arg6, arg7) { funcret func(a, b, c, d, e, f, g); }
      |                                                                                    ^
In file included from x509/openssl_symbols_p.h:64,
                 from x509/openssl_symbols.cpp:57:
/usr/include/openssl/pem.h:330:35: note:   initializing argument 4 of 'int PEM_write_bio_PKCS8PrivateKey(BIO*, EVP_PKEY*, const EVP_CIPHER*, char*, int, int (*)(char*, int, int, void*), void*)'
  330 |                                   char *, int, pem_password_cb *, void *);
      |                                   ^~~~~~
make[2]: *** [Makefile:2717: .obj/openssl_symbols.o] Error 1

```

Could you check that this PR is appropriate for fix that issue. Compilation with that fix finished without problems.
